### PR TITLE
rewrite without execSync (which breaks on windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,10 @@ console.log(git.branch());
 // master
 
 console.log(git.tag());
-// 0.1.0
+// not implemented
 
 console.log(git.log());
-// [
-//   [
-//     '75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef',
-//     'update pjson to include sync exec',
-//     '17 minutes ago',
-//     'kurttheviking'
-//   ],
-//   [
-//     '143120ac3ecc07aeae1462b372bb2033aa20c3ee',
-//     'Merge pull request #6 from shtylman/patch-1',
-//     '1 year, 2 months ago',
-//     'Thomas Blobaum'
-//   ],
-//   ...
-// ]
-
+// not implemented
 ```
 
 You can also run these examples via: `npm run examples`
@@ -73,11 +58,6 @@ return the current tag
 
 ### .branch() => &lt;String&gt;
 return the current branch
-
-
-## Warning
-
-Not tested outside of a *nix system. See the [execSync module notes](https://github.com/mgutz/execSync#notes) on this topic.
 
 
 ## License

--- a/package.json
+++ b/package.json
@@ -12,14 +12,16 @@
       "url": "https://github.com/kurttheviking"
     },
     {
+      "name": "jden",
+      "email": "jason@denizac.org",
+      "url": "http://jden.us"
+    },
+    {
       "name": "Thomas Blobaum",
       "email": "tblobaum@gmail.com",
       "url": "https://github.com/tblobaum"
     }
   ],
-  "dependencies": {
-    "execSync": "1.0.2"
-  },
   "description": "Synchronously get the current git commit hash, tag, or branch",
   "devDependencies": {},
   "homepage": "https://github.com/kurttheviking/git-rev-sync",
@@ -36,5 +38,8 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:kurttheviking/git-rev-sync.git"
+  },
+  "dependencies": {
+    "graceful-fs": "^3.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-rev-sync",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "author": "kurttheviking",
   "bugs": {
     "web": "https://github.com/kurttheviking/git-rev-sync/issues"


### PR DESCRIPTION
now reads directly out of the .git directory

supported functions:
- branch
- long
- short
