### PR TITLE
Use the git packfile if /refs/heads fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,19 @@ function long () {
     return b.substr(11)
   } else {
     var gitDir = getGitDir()
-    var ref = fs.readFileSync(path.resolve(gitDir, 'refs', 'heads', b), 'utf8')
+    var refsFilePath = path.resolve(gitDir, 'refs', 'heads', b)
+    var ref;
+    if (fs.existsSync(refsFilePath)) {
+      ref = fs.readFileSync(refsFilePath, 'utf8')
+    } else {
+      // If there isn't an entry in /refs/heads for this branch, it may be that
+      // the ref is stored in the packfile (.git/packed-refs). Fall back to
+      // looking up the hash here.
+      var refToFind = path.join('refs', 'heads', b)
+      var packfileContents = fs.readFileSync(path.resolve(gitDir, 'packed-refs'), 'utf8')
+      var packfileRegex = new RegExp('(.*) ' + refToFind)
+      ref = packfileRegex.exec(packfileContents)[1]
+    }
     return ref.trim()
   }
 }


### PR DESCRIPTION
When getting the current commit, looking in `/refs/heads` can fail. This is because git sometimes stores these refs in a packfile for performance reasons (https://www.kernel.org/pub/software/scm/git/docs/git-pack-refs.html). If we can't find the commit in `/refs/heads`, we should fall back to look in the packfile.

I'm not confident this is the right approach. It's very weird already to be doing manual operations in the `.git` folder, but I see why that approach was taken here.
