### PR TITLE
Throw when getGitDir(start) runs out of paths to search

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ function getGitDir(start) {
   if (fs.existsSync(testPath)) {
     return testPath
   }
+
+  if (!start.length) {
+    throw new Error('No Git repository found');
+  }
+
   return getGitDir(start)
 }
 


### PR DESCRIPTION
I just tried to use `git-rev-sync` in a project where I hadn't yet `init`ed git; it exploded with 'maximum call stack exceeded,' so I added a `throw Error('No Git repository found')` when the path 'stack' ends up empty.
