### PR TITLE
git.count() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ git-rev-sync
 
 [![Build Status](https://travis-ci.org/kurttheviking/git-rev-sync.svg?branch=master)](https://travis-ci.org/kurttheviking/git-rev-sync.svg?branch=master)
 
-Synchronously get the current git commit hash, tag, branch or commit message. Forked from [git-rev](https://github.com/tblobaum/git-rev).
+Synchronously get the current git commit hash, tag, count, branch or commit message. Forked from [git-rev](https://github.com/tblobaum/git-rev).
 
 
 ## Example
@@ -25,6 +25,9 @@ console.log(git.message());
 
 console.log(git.tag());
 // v1.3.1
+
+console.log(git.count());
+// 60
 
 console.log(git.log());
 // not implemented
@@ -63,6 +66,10 @@ return the current tag; this method will fail if the `git` command is not found 
 #### git.message() &rarr; &lt;String&gt;
 
 return the current commit message; this method will fail if the `git` command is not found in your `PATH`
+
+#### git.count() &rarr; &lt;String&gt;
+
+return the count of commits across all branches; this method will fail if the `git` command is not found in your `PATH`
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -100,6 +100,10 @@ function tag() {
   return _command('git', ['describe', '--always', '--tag', '--abbrev=0']);
 }
 
+function count() {
+  return _command('git', ['rev-list', '--all', '--count']);
+}
+
 function log() {
   throw new Error('not implemented')
 }
@@ -110,5 +114,6 @@ module.exports = {
   long : long,
   message : message,
   short : short,
-  tag : tag
-}
+  tag : tag,
+  count: count
+};

--- a/tests/index.js
+++ b/tests/index.js
@@ -18,4 +18,7 @@ assert.equal(!!result.length, true, 'message() returns a string with non-zero le
 result = git.tag();
 assert.equal(!!result.length, true, 'tag() returns a string with non-zero length');
 
+result = git.count();
+assert.equal(!!result.length, true, 'tag() returns a string with non-zero length');
+
 console.log('tests passed');


### PR DESCRIPTION
I added a method that returns the total count of commits for a repository across all branches.  Includes the appropriate test and updated documentation.  

As for the why? I'm using your module as part of my build process for a mobile app, found it very convenient to use the git.short() value to autopopulate app values that have to be unique with each build published.  I have a similar need when publishing to the Android Platform, but that value has to be numeric.  
