### PR TITLE
added remote-directory support

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,8 +49,12 @@ function _getGitDirectory(start) {
   return _getGitDirectory(start)
 }
 
-function branch () {
-  var gitDir = _getGitDirectory()
+function branch (dir) {
+  var gitDir;
+
+  if (dir) gitDir = _getGitDirectory(dir);
+  else gitDir = _getGitDirectory();
+
   var head = fs.readFileSync(path.resolve(gitDir, 'HEAD'), 'utf8')
   var b = head.match(RE_BRANCH)
 
@@ -61,8 +65,8 @@ function branch () {
   return 'Detatched: ' + head.trim()
 }
 
-function long() {
-  var b = branch()
+function long(dir) {
+  var b = branch(dir)
 
   if (/Detatched: /.test(b)) {
     return b.substr(11)
@@ -88,8 +92,8 @@ function long() {
   return ref.trim()
 }
 
-function short() {
-  return long().substr(0, 7)
+function short(dir) {
+  return long(dir).substr(0, 7)
 }
 
 function message() {


### PR DESCRIPTION
Similar to this implementation: https://www.npmjs.com/package/git-rev-2

I added the ability for a user to supply which directory they wanted to parse git info from (if left blank, it uses the current implementation).

Reasoning: I was using this package for doing some file copying from a 'parent' repository to several child applications, but wanted to only allow it to happen if the parent/children repos currently had 'allowed' branches checked out (otherwise, the files would not copy until the repos were using the correct branch(es));
