### PR TITLE
Added tagOrHash method that shows a tag if exists, otherwise prints a commit hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ return the current branch; optional `filePath` parameter can be used to run the 
 
 return the current tag and mark as dirty if markDirty is truthful; this method will fail if the `git` command is not found in your `PATH`
 
+#### `git.tagOrHash()` &rarr; &lt;String&gt;
+
+return the result of `git describe --tags --abbrev=40`; this method will fail if the `git` command is not found in your `PATH`
+
 #### `git.message()` &rarr; &lt;String&gt;
 
 return the current commit message; this method will fail if the `git` command is not found in your `PATH`

--- a/index.js
+++ b/index.js
@@ -114,6 +114,10 @@ function tag(markDirty) {
   return _command('git', ['describe', '--always', '--tag', '--abbrev=0']);
 }
 
+function tagOrHash() {
+  return _command('git', ['describe', '--tags', '--abbrev=40']);
+}
+
 function count() {
   return parseInt(_command('git', ['rev-list', '--all', '--count']), 10);
 }
@@ -129,5 +133,6 @@ module.exports = {
   long : long,
   message : message,
   short : short,
-  tag : tag
+  tag : tag,
+  tagOrHash : tagOrHash,
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -18,6 +18,9 @@ assert.equal(!!result.length, true, 'message() returns a string with non-zero le
 result = git.tag();
 assert.equal(!!result.length, true, 'tag() returns a string with non-zero length');
 
+result = git.tagOrHash();
+assert.equal(!!result.length, true, 'tagOrHash() returns a string with non-zero length');
+
 result = git.count();
 assert.notEqual(result, 0, 'count() returns a non-zero number');
 assert.equal(Math.abs(result), result, 'count() returns a positive number');


### PR DESCRIPTION
I was thinking that it might be useful to display version number only in some cases and hash as a fallback only.
