### PR TITLE
The name of the branch should be escaped when creating a Regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function long(dir) {
     // looking up the hash here.
     var refToFind = ['refs', 'heads', b].join('/');
     var packfileContents = fs.readFileSync(path.resolve(gitDir, 'packed-refs'), 'utf8');
-    var packfileRegex = new RegExp('(.*) ' + refToFind);
+    var packfileRegex = new RegExp('(.*) ' + escapeRegex(refToFind));
     ref = packfileRegex.exec(packfileContents)[1];
   }
 
@@ -120,6 +120,13 @@ function count() {
 
 function log() {
   throw new Error('not implemented');
+}
+
+function escapeRegex(string) {
+  // the following Regex will match reserved Regex symbols
+  var regexToEscape = /[|\\{}()[\]^$+*?.]/g;
+
+  return string.replace(regexToEscape, '\\$&');
 }
 
 module.exports = {


### PR DESCRIPTION
I currently have a module that uses `git-rev-sync` to get the short hash of the repo.

It fails when attempting to match the contents of the `.git/packed-refs` file because my branch is named `fix/webpack+node`

Could bring in https://www.npmjs.com/package/escape-string-regexp as a dep but I'm not 100% how you feel about that.
