### PR TITLE
Add isTagDirty();

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ return the current branch; optional `filePath` parameter can be used to run the 
 
 return the current tag and mark as dirty if markDirty is truthful; this method will fail if the `git` command is not found in your `PATH`
 
+#### `git.isTagDirty()` &rarr; &lt;Boolean&gt;
+
+returns true if the current tag is dirty.
+
 #### `git.message()` &rarr; &lt;String&gt;
 
 return the current commit message; this method will fail if the `git` command is not found in your `PATH`

--- a/index.js
+++ b/index.js
@@ -114,6 +114,18 @@ function tag(markDirty) {
   return _command('git', ['describe', '--always', '--tag', '--abbrev=0']);
 }
 
+function isTagDirty() {
+  try {
+    _command('git', ['describe', '--exact-match', '--tags']);
+  } catch (e) {
+    if (e.message.indexOf('no tag exactly matches')) {
+      return true;
+    }
+    throw e;
+  }
+  return false;
+}
+
 function count() {
   return parseInt(_command('git', ['rev-list', '--all', '--count']), 10);
 }
@@ -129,5 +141,6 @@ module.exports = {
   long : long,
   message : message,
   short : short,
-  tag : tag
+  tag : tag,
+  isTagDirty: isTagDirty
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -22,4 +22,7 @@ result = git.count();
 assert.notEqual(result, 0, 'count() returns a non-zero number');
 assert.equal(Math.abs(result), result, 'count() returns a positive number');
 
+result = git.isTagDirty();
+assert.equal(typeof result, 'boolean', 'isTagDirty() returns a boolean');
+
 console.log('tests passed');


### PR DESCRIPTION
`tag(true)` doesn't work for me because of `--abbrev=0`.

This pr adds a function which returns if the tag is dirty.

In my opinion a function which returns a boolean is even cleaner than a dirty tag name.

What do you think?
