### PR TITLE
Add submodule support

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,11 @@ function _getGitDirectory(start) {
   testPath = path.resolve(testPath, '.git');
 
   if (fs.existsSync(testPath)) {
+    if (!fs.statSync(testPath).isDirectory()) {
+      var parentRepoPath = fs.readFileSync(testPath, 'utf8').substring(8).trim();
+      return path.resolve(parentRepoPath);
+    }
+    
     return testPath;
   }
 
@@ -59,7 +64,7 @@ function _getGitDirectory(start) {
 
 function branch(dir) {
   var gitDir = _getGitDirectory(dir);
-
+  
   var head = fs.readFileSync(path.resolve(gitDir, 'HEAD'), 'utf8');
   var b = head.match(RE_BRANCH);
 


### PR DESCRIPTION
To test this:
1. Make parent repo
2. Make another repo which is submodule of parent repo
3. Close parent repo to your computer recursively (git clone --recursive xxx)
4. Use git-rev-sync in submodule and it should be able to use git-rev-sync normally. I tested with short() function.

Before this pull request git-rev-sync wasnt able to work when repo is cloned recursively in child repo. This was because child repo has .git FILE not FOLDER. That file contains path to it's git folder :)

Tell me if your need help or have something to comment :D
