### PR TITLE
Added possibility of getting tag name from different directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function _command(cmd, args, { cwd }) {
   var result;
 
   if (HAS_NATIVE_EXECSYNC) {
-    result = childProcess.spawnSync(cmd, args, { cwd });
+    result = childProcess.spawnSync(cmd, args, { cwd } = {});
 
     if (result.status !== 0) {
       throw new Error('[git-rev-sync] failed to execute command: ' + result.stderr);

--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ var HAS_NATIVE_EXECSYNC = childProcess.hasOwnProperty('spawnSync');
 var PATH_SEP = path.sep;
 var RE_BRANCH = /^ref: refs\/heads\/(.*)\n/;
 
-function _command(cmd, args, { cwd }) {
+function _command(cmd, args, { cwd } = {}) {
   var result;
 
   if (HAS_NATIVE_EXECSYNC) {
-    result = childProcess.spawnSync(cmd, args, { cwd } = {});
+    result = childProcess.spawnSync(cmd, args, { cwd });
 
     if (result.status !== 0) {
       throw new Error('[git-rev-sync] failed to execute command: ' + result.stderr);

--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ var HAS_NATIVE_EXECSYNC = childProcess.hasOwnProperty('spawnSync');
 var PATH_SEP = path.sep;
 var RE_BRANCH = /^ref: refs\/heads\/(.*)\n/;
 
-function _command(cmd, args) {
+function _command(cmd, args, { cwd }) {
   var result;
 
   if (HAS_NATIVE_EXECSYNC) {
-    result = childProcess.spawnSync(cmd, args);
+    result = childProcess.spawnSync(cmd, args, { cwd });
 
     if (result.status !== 0) {
       throw new Error('[git-rev-sync] failed to execute command: ' + result.stderr);
@@ -122,12 +122,12 @@ function message() {
   return _command('git', ['log', '-1', '--pretty=%B']);
 }
 
-function tag(markDirty) {
+function tag(markDirty, dir) {
   if (markDirty) {
-    return _command('git', ['describe', '--always', '--tag', '--dirty', '--abbrev=0']);
+    return _command('git', ['describe', '--always', '--tag', '--dirty', '--abbrev=0'], { cwd: dir });
   }
 
-  return _command('git', ['describe', '--always', '--tag', '--abbrev=0']);
+  return _command('git', ['describe', '--always', '--tag', '--abbrev=0'], { cwd: dir });
 }
 
 function isTagDirty() {


### PR DESCRIPTION
Right now I can get branch name from different directory than my current working directory. Tag is often used alongside with the branch name, that's why it would be fine to have access to tag name from different repository as well.

In this PR I am passing directory string as a options.cwd parameter for child_proces.spawnSync method.
Method documentation is [here](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options)