### PR TITLE
Ability to specify short hash length

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,8 +114,8 @@ function long(dir) {
   return ref.trim();
 }
 
-function short(dir) {
-  return long(dir).substr(0, 7);
+function short(dir, len) {
+  return long(dir).substr(0, len || 7);
 }
 
 function message() {


### PR DESCRIPTION
- Added option to specify desired length of short hash
- Kept default at 7 to avoid breaking changes
- Fixes #38, or at least addresses it