### PR TITLE
also output errors when spawnSync fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function _command(cmd, args) {
     result = childProcess.spawnSync(cmd, args);
 
     if (result.status !== 0) {
-      throw new Error('[git-rev-sync] failed to execute command: ' + result.stderr);
+      throw new Error('[git-rev-sync] failed to execute command: ' + result.stderr + '/' + result.error);
     }
 
     return result.stdout.toString('utf8').replace(/^\s+|\s+$/g, '');


### PR DESCRIPTION
If you execute any git commands (e.g. when calling `remoteUrl()`) but on a machine without git (e.g. docker) the output will return `null` as error, since this is what `spawnSync` returns as stderr. It is not very helpful:

```
Error: [git-rev-sync] failed to execute command: null
    at _command (/app/node_modules/git-rev-sync/index.js:20:13)
    at Object.remoteUrl (/app/node_modules/git-rev-sync/index.js:160:10)
    at [...]
```

The `error` field on the other hand will contain something like "Error: spawnSync git ENOENT" which is also not the most user-friendly message but might point you in the right direction that `git` the executable is missing. `ENOENT` is unix lingo for "error no entry". This PR adds this error field so that the error message then looks like this:

```
Error: [git-rev-sync] failed to execute command: null/Error: spawnSync git ENOENT
    at _command (/app/node_modules/git-rev-sync/index.js:20:13)
    at Object.remoteUrl (/app/node_modules/git-rev-sync/index.js:160:10)
    at [...]
```

I now know why the error occurs in my Docker image, but it might be helpful to others, too, to find a solution more quickly.