### PR TITLE
Renamed isDirty to hasUnstagedChanges & added correct isDirty

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,9 +138,13 @@ function tagFirstParent(markDirty) {
     return _command('git', ['describe', '--always', '--tag', '--abbrev=0', '--first-parent']);
 }
 
-function isDirty() {
+function hasUnstagedChanges() {
   var writeTree = _command('git', ['write-tree']);
   return _command('git', ['diff-index', writeTree, '--']).length > 0;
+}
+
+function isDirty() {
+  return _command('git', ['diff-index', 'HEAD', '--']).length > 0;
 }
 
 function isTagDirty() {
@@ -176,6 +180,7 @@ module.exports = {
   branch : branch,
   count: count,
   date: date,
+  hasUnstagedChanges: hasUnstagedChanges,
   isDirty: isDirty,
   isTagDirty: isTagDirty,
   log: log,


### PR DESCRIPTION
Documentation was incorrect; isDirty() in previous commits actually told you whether or not you have unstaged changes.

I fixed this, but also retained the previous behavior in hasUnstagedChanges()