### PR TITLE
graceful-fs@4.1.15 and relax dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "escape-string-regexp": "1.0.5",
-    "graceful-fs": "4.1.11",
+    "graceful-fs": "^4.1.15",
     "shelljs": "0.7.7"
   },
   "devDependencies": {}


### PR DESCRIPTION
It may not be relevant to the use that this package makes but `graceful-fs` had a potential memory leak fixed in `4.1.15`. Additionally, unless there is known to be something broken in a higher version it is nice to have relaxed version requirements (`^` or `~`). Relaxed versions reduces the number of duplicate versions yarn/npm needs to install.

Reference: https://github.com/isaacs/node-graceful-fs/issues/102