### PR TITLE
fix: worktree issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,10 @@ function long(dir) {
   }
 
   var gitDir = _getGitDirectory(dir);
-  var refsFilePath = path.resolve(gitDir, 'refs', 'heads', b);
+  var gitRootDir = gitDir.indexOf('.git/worktrees/') > 0 ?
+    gitDir.replace(/\.git\/worktrees\/.+$/, '.git') :
+    gitDir;
+  var refsFilePath = path.resolve(gitRootDir, 'refs', 'heads', b);
   var ref;
 
   if (fs.existsSync(refsFilePath)) {


### PR DESCRIPTION
refs store inside root of .git folder, not inside worktree folders.
If run the command inside a folder created by `git worktree`, `gitDir` will be something like `repo-name/.git/worktrees/repo-name`, while `refs` actually stores inside `repo-name/.git/refs` not inside `repo-name/.git/worktrees/repo-name/refs`.
This modification is to ensure it will look for `refs` in correct place.