### PR TITLE
Update shelljs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "escape-string-regexp": "1.0.5",
     "graceful-fs": "4.1.15",
-    "shelljs": "0.7.7"
+    "shelljs": "0.8.4"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Needed to eliminate warnings on Node v14. See https://github.com/shelljs/shelljs/issues/991.