### PR TITLE
Improve short api design

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ var git = require('git-rev-sync');
 console.log(git.short());
 // 75bf4ee
 
+console.log(git.short(10));
+// 75bf4eea9a
+
 console.log(git.long());
 // 75bf4eea9aa1a7fd6505d0d0aa43105feafa92ef
 

--- a/index.js
+++ b/index.js
@@ -115,6 +115,10 @@ function long(dir) {
 }
 
 function short(dir, len) {
+  if(Number.isInteger(dir)) {
+    return long(undefined).substr(0, dir);
+  }
+
   return long(dir).substr(0, len || 7);
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -9,6 +9,9 @@ assert.equal(result.length > 3, true, 'short() returns string of length 4+');
 result = git.short(null, 8);
 assert.equal(result.length === 8, true, 'short() returns string of length 4+');
 
+result = git.short(10);
+assert.equal(result.length === 10, true, 'short() returns string of length 10');
+
 result = git.long();
 assert.equal(result.length > 38, true, 'long() returns string of length 39+');
 


### PR DESCRIPTION
If we want to use `short` api with a specific length, we have to send `null` or `undefined` for the first argument
in this PR we have a new design of `short` api that we can send just `length`

before
```js
git.short(null, 10)
```

now
```js
git.short(10)
```