### PR TITLE
add optional `branch` parameter to count function

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ return the result of `git rev-parse HEAD`; optional `filePath` parameter can be 
 
 return the current branch; optional `filePath` parameter can be used to run the command against a repo outside the current working directory
 
-#### `git.count()` &rarr; &lt;Number&gt;
+#### `git.count([branch])` &rarr; &lt;Number&gt;
 
-return the count of commits across all branches; this method will fail if the `git` command is not found in `PATH`
+returns the count of commits across all branches; optional `branch` parameter can be used to limit the count to a specific branch; this method will fail if the `git` command is not found in `PATH`
 
 #### `git.date()` &rarr; &lt;Date&gt;
 

--- a/index.js
+++ b/index.js
@@ -168,8 +168,8 @@ function date() {
   return new Date(_command('git', ['log', '--no-color', '-n', '1', '--pretty=format:"%ad"']));
 }
 
-function count() {
-  return parseInt(_command('git', ['rev-list', '--all', '--count']), 10);
+function count(branch) {
+  return parseInt(_command('git', ['rev-list', '--count', branch || '--all']), 10);
 }
 
 function log() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -19,6 +19,10 @@ result = git.count();
 assert.notEqual(result, 0, 'count() returns a non-zero number');
 assert.equal(Math.abs(result), result, 'count() returns a positive number');
 
+result = git.count('HEAD');
+assert.notEqual(result, 0, 'count() returns a non-zero number');
+assert.equal(Math.abs(result), result, 'count() returns a positive number');
+
 result = git.date();
 assert.equal(result instanceof Date, true, 'date() returns a date');
 


### PR DESCRIPTION
This library is SO useful! Thanks for your efforts on it.

This PR adds an optional `branch` parameter to the count function. This helped me have a more consistently incrementing build number on a specific branch as opposed to counting the total number of commits in the repo.